### PR TITLE
guard Locate0 with a write Lock

### DIFF
--- a/hashring.go
+++ b/hashring.go
@@ -32,7 +32,7 @@ type HashRing struct {
 	idx          nodeIdx           // sorted indexes
 	replicaCount int               // replicas to be inserted
 	hash         hash.Hash32
-	mu           sync.RWMutex // to protect above fields
+	mu           sync.Mutex // to protect above fields
 }
 
 // New returns a Hash ring with provided virtual node count and hash
@@ -111,8 +111,8 @@ func (hr *HashRing) Delete(node string) error {
 
 // Locate returns the node for a given key
 func (hr *HashRing) Locate(key string) (node string, err error) {
-	hr.mu.RLock()
-	defer hr.mu.RUnlock()
+	hr.mu.Lock()
+	defer hr.mu.Unlock()
 
 	if len(hr.idx) < 1 {
 		return node, fmt.Errorf("no available nodes")

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -1,8 +1,10 @@
 package hashring
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 )
 
@@ -201,4 +203,29 @@ func TestHashRing_Get(t *testing.T) {
 		}
 	}
 
+}
+
+func BenchmarkHashRing_Get(b *testing.B) {
+	n := 5
+	c := 32
+
+	hr := New(n, nil)
+	for i := 1; i <= n; i++ {
+		hr.Add(fmt.Sprintf("127.0.0.%d", i))
+	}
+
+	b.ResetTimer()
+
+	for i := 2; i <= c; i *= 2 {
+		b.Run(strconv.Itoa(i), func(b *testing.B) {
+			b.SetParallelism(i)
+			b.RunParallel(func(pb *testing.PB) {
+				k := 0
+				for pb.Next() {
+					k++
+					hr.Locate(strconv.Itoa(k))
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
Per issue #3 right now the Locate() method calls hash.Reset() which appears to need to be guarded by a write Lock.

Since that appears to be the only time RLock/RUnlock is used, I've switched it from a sync.RWMutex to a sync.Mutex.

I've included a variation of the benchmark test I was using, with `-race` detection enabled, when I saw the condition.